### PR TITLE
Add Node.js OS Network Interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@ Compiling a list of web development dependencies and their support on the Window
 - [x] [rbenv](https://github.com/rbenv/rbenv)
 - [x] [Ruby](https://www.ruby-lang.org/)
 - [x] [Ruby on Rails](http://rubyonrails.org/)
-- [ ] [Node.js OS Network Interfaces](https://github.com/Microsoft/BashOnWindows/issues/468) (Requirement of [Browsersync](https://browsersync.io/), [Yeoman](http://yeoman.io/), [Hexo](https://hexo.io/), many others)
+
+## Known issues
+
+There are some known overarching issues that affect a broad range of programs:
+
+- Node.js Network Interface ([#468](https://github.com/Microsoft/BashOnWindows/issues/468))
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Compiling a list of web development dependencies and their support on the Window
 - [x] [rbenv](https://github.com/rbenv/rbenv)
 - [x] [Ruby](https://www.ruby-lang.org/)
 - [x] [Ruby on Rails](http://rubyonrails.org/)
+- [ ] [Node.js OS Network Interfaces](https://github.com/Microsoft/BashOnWindows/issues/468) (Requirement of [Browsersync](https://browsersync.io/), [Yeoman](http://yeoman.io/), [Hexo](https://hexo.io/), many others)
 
 ## Contributing
 


### PR DESCRIPTION
Open to re-formatting this, as it felt a bit much to list every one of the affected libraries when the core issue is known, but it's the biggest reason I haven't been able to make much use of Bash on Windows. Almost any Node.js library that creates a local server fails until the fix for Microsoft/BashOnWindows#468 comes down the pipe.